### PR TITLE
arm: DT: Rhine: Remove DDR50 limitation for SDHC1

### DIFF
--- a/arch/arm/boot/dts/msm8974-rhine_amami_row.dtsi
+++ b/arch/arm/boot/dts/msm8974-rhine_amami_row.dtsi
@@ -1200,10 +1200,6 @@
 	};
 };
 
-&sdhc_1 {
-	qcom,bus-speed-mode = "DDR_1p8v";
-};
-
 &sdhc_2 {
 	qcom,pad-drv-on = <0x4 0x2 0x2>; /* 10mA, 6mA, 6mA */
 	qcom,vdd-current-level = <400000 400000>;

--- a/arch/arm/boot/dts/msm8974-rhine_honami_row.dtsi
+++ b/arch/arm/boot/dts/msm8974-rhine_honami_row.dtsi
@@ -1205,10 +1205,6 @@
 	};
 };
 
-&sdhc_1 {
-	qcom,bus-speed-mode = "DDR_1p8v";
-};
-
 &sdhc_2 {
 	qcom,pad-drv-on = <0x4 0x2 0x2>; /* 10mA, 6mA, 6mA */
 	qcom,vdd-current-level = <400000 400000>;

--- a/arch/arm/boot/dts/msm8974-rhine_togari_row.dtsi
+++ b/arch/arm/boot/dts/msm8974-rhine_togari_row.dtsi
@@ -1137,10 +1137,6 @@
 	};
 };
 
-&sdhc_1 {
-	qcom,bus-speed-mode = "DDR_1p8v";
-};
-
 &sdhc_2 {
 	qcom,pad-drv-on = <0x7 0x2 0x2>; /* 16mA, 6mA, 6mA */
 	qcom,vdd-current-level = <400000 400000>;


### PR DESCRIPTION
Actually, MSM8974 supports HS200/HS400 mode! Also, the eMMC in
Honami (also found in other devices) is a Samsung MAG2GC, that
supports HS400.
There is no reason to limit our speed.

[tomascus: modified for 3.4 kernel]

Change-Id: Ia9ecd2c7d609933c1a93604677cedac278b8c0ae

