### PR TITLE
Revert "block: fix use-after-free in sys_ioprio_get()"

### DIFF
--- a/fs/ioprio.c
+++ b/fs/ioprio.c
@@ -144,7 +144,6 @@ static int get_task_ioprio(struct task_struct *p)
 	ret = security_task_getioprio(p);
 	if (ret)
 		goto out;
-	task_lock(p);
 	ret = IOPRIO_PRIO_VALUE(IOPRIO_CLASS_NONE, IOPRIO_NORM);
 	task_lock(p);
 	if (p->io_context)


### PR DESCRIPTION
- Extra lock causes system hang/reboot when 'android_get_ioprio' is called.
  The so called '3AM' reboot is fixed with this

This reverts commit 2039e23cc37abafa0a804b3567428c97e23f1d84.

Change-Id: Ifc5cb65f68c1d66e8f8e8bbf8dbbd5136dfa048a

